### PR TITLE
Typo fix of trademark flavor text.

### DIFF
--- a/html/cart.php
+++ b/html/cart.php
@@ -140,7 +140,7 @@ if(isset($_POST['code']) && !empty($_POST['code']))
       </div>
       <footer class="pt-2 mt-4 text-muted border-top">
           Copyright (c) Keeree Joe Group. 2064.
-          CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+          CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
       </footer>
     </div>
   </main>

--- a/html/checkout.php
+++ b/html/checkout.php
@@ -206,7 +206,7 @@ require_once '../lib/drinksLib.php';
     </div>
     <footer class="pt-2 mt-4 text-muted border-top">
       Copyright (c) Keeree Joe Group. 2064.
-      CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+      CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
     </footer>
   </main>
 

--- a/html/drinkProfile.php
+++ b/html/drinkProfile.php
@@ -169,7 +169,7 @@ function drinkERROR()
       </div>
       <footer class="pt-2 mt-4 text-muted border-top">
         Copyright (c) Keeree Joe Group. 2064.
-        CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+        CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
       </footer>
     </div>
   </main>

--- a/html/drinks.php
+++ b/html/drinks.php
@@ -315,7 +315,7 @@ require_once '../lib/drinksLib.php';
     </div>
     <footer class="pt-2 mt-4 text-muted border-top">
       Copyright (c) Keeree Joe Group. 2064.
-      CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+      CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
     </footer>
 
   </main>

--- a/html/employee.php
+++ b/html/employee.php
@@ -357,7 +357,7 @@ if(isset($_POST['restock']))
       </div>
       <footer class="pt-2 mt-4 text-muted border-top">
         Copyright (c) Keeree Joe Group. 2064.
-        CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+        CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
       </footer>
     </div>
   </main>

--- a/html/index.php
+++ b/html/index.php
@@ -93,7 +93,7 @@
   </main>
   <footer class="text-muted text-center">
       Copyright (c) Keeree Joe Group. 2064.
-      CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+      CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
   </footer>
 
     <!-- Bootstrap JavaScript Libraries -->

--- a/html/orderTrack.php
+++ b/html/orderTrack.php
@@ -99,7 +99,7 @@ require_once '../lib/drinksLib.php';
     </div>
     <footer class="pt-2 mt-4 text-muted border-top">
       Copyright (c) Keeree Joe Group. 2064.
-      CALICOMP and Keeree Joe Group are registered tademarks of Banjo Group.
+      CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group.
     </footer>
   </main>
   <!-- Bootstrap JavaScript Libraries -->


### PR DESCRIPTION
`Copyright (c) Keeree Joe Group. 2064. CALICOMP and Keeree Joe Group are registered trademarks of Banjo Group. ` incorrectly said "tademark" instead of trademark.